### PR TITLE
Use GNU date and sed by default on macOS

### DIFF
--- a/lectl
+++ b/lectl
@@ -94,8 +94,8 @@
 # Create auto-update version (comming soon)
 
 #Variables for utilities
-_date=date #Change date by gdate if you are using homebrew on OS X
-_sed=sed   #Change sed by gsed if you are using homebrew on OS X
+_date=date
+_sed=sed
 _grep=grep
 _curl=curl
 _awk=awk
@@ -105,6 +105,12 @@ _column=column
 _tail=tail
 _tr=tr
 _wc=wc
+
+# macOS compatibility
+if [ "$(uname)" = "Darwin" ]; then
+    _date=gdate
+    _sed=gsed
+fi
 
 # Script version/name variables
 version='0.11'


### PR DESCRIPTION
Related to #4.

I think it makes sense to use GNU utils by default on macOS. If those are not installed you'll get a proper error message. (`Sorry, I can't continue, I need "gdate" to run.`) Way better than the current (misleading) ~error~ message (`Info: I've not found any certificate for the domain letsencryt.org`) IMHO.